### PR TITLE
optimization to initial movie logging flow

### DIFF
--- a/src/MovieLogger.jsx
+++ b/src/MovieLogger.jsx
@@ -9,7 +9,9 @@ function MovieLogger() {
   const [userMovies, setUserMovies] = useState([]);
   const [loading, setLoading] = useState(true);
   const [moviesLogged, setMoviesLogged] = useState(0);
-
+  const [showFirstSearch, setShowFirstSearch] = useState(true);
+  const [showSecondSearch, setShowSecondSearch] = useState(true);
+  const [showThirdSearch, setShowThirdSearch] = useState(true);
   useEffect(() => {
     if (currentUser) {
       fetch(`http://localhost:3000/users/userMovies/${currentUser.uid}`)
@@ -24,8 +26,19 @@ function MovieLogger() {
         });
     }
   }, [currentUser, moviesLogged]);
-  const handleMovieLogged = () => {
+  const handleMovieLogged = (searchId) => {
+    console.log("hello")
     setMoviesLogged(moviesLogged + 1);
+    if (searchId==1){
+      setShowFirstSearch(false)
+    }
+    if (searchId==2){
+      setShowSecondSearch(false)
+    }
+    if (searchId==3){
+      setShowThirdSearch(false)
+    }
+
   };
   if (loading) {
     return <p>Loading...</p>;
@@ -35,18 +48,35 @@ function MovieLogger() {
     return (
       <div>
         <FlixterHeader />
+
         <div className="loggingContainer">
+
+
+          {showFirstSearch &&
+          <>
           <div className="question">
             What is one movie that you really enjoyed?
           </div>
-          <MovieSearch initialRating={7.5} onMovieLogged={handleMovieLogged} />
+          <MovieSearch initialRating={7.5} onMovieLogged={()=>{handleMovieLogged(1)}} />
+          </>
+  }
+
+          {showSecondSearch &&
+          <>
           <div className="question">
-            What is one movie that you did not like?
-          </div>
-          <MovieSearch initialRating={2.5} onMovieLogged={handleMovieLogged} />
-          <div className="question">What is one movie that was just ok?</div>
-          <MovieSearch initialRating={5} onMovieLogged={handleMovieLogged} />
+          What is one movie that you did not like?
         </div>
+          <MovieSearch initialRating={2.5} onMovieLogged={()=>{handleMovieLogged(2)}} />
+          </>
+          }
+          {showThirdSearch &&
+          <>
+                    <div className="question">What is one movie that was just ok?</div>
+
+          <MovieSearch initialRating={5} onMovieLogged={()=>{handleMovieLogged(3)}} />
+          </>
+          }
+          </div>
       </div>
     );
   }


### PR DESCRIPTION
Users are now restricted to logging just one favorable movie, one unfavorable movie, and one average movie during the initial logging process. This change addresses potential ranking discrepancies that previously arose from initiating movie logs with three movies of equal ranking