### PR TITLE
Streaming api for movies

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 VITE_API_KEY=eyJhbGciOiJIUzI1NiJ9.eyJhdWQiOiI4M2Y0ZGE0MjI0M2IxNDljZmRjM2E2YmM4MWI1OGVkNSIsInN1YiI6IjY2Njc2NGRlMDdmNzg5ZGYzMTk5ZmI2MyIsInNjb3BlcyI6WyJhcGlfcmVhZCJdLCJ2ZXJzaW9uIjoxfQ.TpNQ6V0IuyirQEQTh3f7XMeE7SOItQeymtCD1oCUy8Y
 # import.meta.env.VITE_API_KEY
-
+VITE_STREAMING_API_KEY=iS5iikAXKIirrdFWPs3k5W3rcX6OFjEoxBUr3Ps6 
 
 # This was inserted by `prisma init`:
 # Environment variables declared in this file are automatically made available to Prisma.

--- a/Routes/users.js
+++ b/Routes/users.js
@@ -131,6 +131,7 @@ router.get("/userMovies/:userId", async (req, res) => {
         genres: um.movie.genres,
         rating: um.rating,
         comparisons: um.comparisons,
+        tmdbId: um.movie.tmdbId,
       }))
     );
   } catch (error) {

--- a/fetchTMDBID.js
+++ b/fetchTMDBID.js
@@ -37,9 +37,6 @@ async function fetchAndUpdateMovie(movie) {
         tmdbId: movieData.id,
       },
     });
-    console.log(`Updated movie: ${movie.title}`);
-  } else {
-    console.log(`No data found for movie: ${movie.title}`);
   }
 }
 

--- a/fetchTMDBID.js
+++ b/fetchTMDBID.js
@@ -1,0 +1,62 @@
+import fetch from "node-fetch";
+import { PrismaClient } from "@prisma/client";
+import Bottleneck from "bottleneck";
+import dotenv from "dotenv";
+dotenv.config();
+
+const prisma = new PrismaClient();
+const apiKey = process.env.VITE_API_KEY; // Ensure your API key is loaded from .env
+
+// Initialize the limiter to handle up to 50 requests per second
+const limiter = new Bottleneck({
+  minTime: 100,
+  maxConcurrent: 1,
+  highWater: 10000,
+});
+
+async function fetchAndUpdateMovie(movie) {
+  const cleanedTitle = movie.title.slice(0, -6);
+  const url = `https://api.themoviedb.org/3/search/movie?api_key=${apiKey}&query=${encodeURIComponent(
+    cleanedTitle
+  )}`;
+  const options = {
+    method: "GET",
+    headers: {
+      accept: "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+  };
+
+  const response = await fetch(url, options);
+  const data = await response.json();
+  const movieData = data.results[0];
+  if (movieData) {
+    await prisma.movie.update({
+      where: { movieId: movie.movieId },
+      data: {
+        tmdbId: movieData.id,
+      },
+    });
+    console.log(`Updated movie: ${movie.title}`);
+  } else {
+    console.log(`No data found for movie: ${movie.title}`);
+  }
+}
+
+async function updateMovieIds() {
+  try {
+    const movies = await prisma.movie.findMany({
+      where: {
+        tmdbId: null,
+      },
+    });
+
+    movies.forEach((movie) => {
+      limiter.schedule(fetchAndUpdateMovie, movie);
+    });
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+updateMovieIds();

--- a/prisma/migrations/20240723173417_tmdb_id/migration.sql
+++ b/prisma/migrations/20240723173417_tmdb_id/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Movie" ADD COLUMN     "tmdbId" INTEGER;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,6 +27,7 @@ model Movie {
   title    String
   genres   String
   users    UserMovies[]
+  tmdbId     Int?   // Optional field for TMDb ID
   bookmarks   BookmarkedMovie[]
 
 }

--- a/src/Bookmarks.jsx
+++ b/src/Bookmarks.jsx
@@ -3,10 +3,20 @@ import FlixterHeader from "./FlixterHeader";
 import "./Bookmarks.css";
 import MovieCard from "./MovieCard";
 import { useAuth } from "./contexts/authContext";
-
+import CreateModal from "./Modal";
 function Bookmarks() {
   const { currentUser } = useAuth();
   const [data, setData] = useState();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [selectedMovie, setSelectedMovie] = useState(null);
+  const openModal = (movie) => {
+    setSelectedMovie(movie);
+    setIsModalOpen(true);
+  };
+  const closeModal = () => {
+    setIsModalOpen(false);
+    setSelectedMovie(null);
+  };
   function unbookmarkMovie(movieId) {
     const userId = currentUser.uid;
     fetch("http://localhost:3000/users/bookmarkMovie", {
@@ -36,6 +46,8 @@ function Bookmarks() {
       movieId={bookmark.movieId}
       unbookmark={unbookmarkMovie}
       includeUnbookmark={true}
+      tmdbId={bookmark.movie.tmdbId}
+      openModal={() => openModal(bookmark.movie)}
     />
   ));
   useEffect(() => {
@@ -50,6 +62,14 @@ function Bookmarks() {
   return (
     <div className="rankingsPage">
       <FlixterHeader></FlixterHeader>
+      {selectedMovie && (
+        <CreateModal
+          isOpen={isModalOpen}
+          close={closeModal}
+          movie={selectedMovie}
+        />
+      )}
+
       <div className="rankingsTitle">Bookmarks</div>
       <div className="sub">Your Next Watch?</div>
       <div className="bookmarksContainer">{movieCards}</div>

--- a/src/MovieCard.css
+++ b/src/MovieCard.css
@@ -64,3 +64,6 @@
   box-sizing: border-box;
   margin-top: 10px;
 }
+.streamingPlatforms {
+  color: white;
+}

--- a/src/MovieCard.jsx
+++ b/src/MovieCard.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import "./MovieCard.css";
 import { CiHeart } from "react-icons/ci";
 import { FaHeart } from "react-icons/fa";
@@ -18,14 +18,38 @@ function MovieCard({
   movieId,
   unbookmark,
   includeUnbookmark,
+  tmdbId,
 }) {
-  const [bookmarked, setBookmarked] = useState(false);
-  //toggles movie as watched
-  const toggleWathchedInternal = (event) => {
-    toggleWatched(movieTitle);
-  };
+  const apiKey = import.meta.env.VITE_STREAMING_API_KEY;
 
-  // const isFavorite = !!likedMovies[movieTitle];
+  const [bookmarked, setBookmarked] = useState(false);
+  const [uniquePlatforms, setUniquePlatforms] = useState(new Set());
+  //toggles movie as watched
+
+  useEffect(() => {
+    if (tmdbId) {
+      const url = `https://api.watchmode.com/v1/title/movie-${tmdbId}/sources?apiKey=${apiKey}&regions=US`;
+      fetch(url)
+        .then((response) => response.json())
+        .then((data) => {
+          const newPlatforms = new Set();
+
+          data.forEach((item) => {
+            if (item.name) {
+              newPlatforms.add(item.name);
+            }
+          });
+          setUniquePlatforms(newPlatforms);
+
+          console.log(
+            "Unique Streaming Platforms:",
+            Array.from(uniquePlatforms)
+          );
+          return uniquePlatforms;
+        });
+    }
+  }, [tmdbId]);
+
   const ratingColor = getRatingColor(movieRating);
   return (
     <div className="movieCard" onClick={openModal}>
@@ -63,6 +87,16 @@ function MovieCard({
           </button>
         )}
       </div>
+      {unbookmark && (
+        <div className="streamingPlatforms">
+          <h3>Available Streaming Platforms:</h3>
+          <ul>
+            {Array.from(uniquePlatforms).map((platform) => (
+              <li key={platform}>{platform}</li>
+            ))}
+          </ul>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Added Streaming Api to bookmarked recommendations, this way if you want to watch one of the recs we picked, you can see where its available.

Added API key for access
in fetchtmdbid.js: script to string match Movie titles from database to movie TMDB movie Ids
This was necessary because all streaming availability APIS either have IMDB or TMDB id as input
In prisma files: added TMDB Id as field in user table
in moviecard.jsx: Added fetch and logic for displaying movie streaming availability
<img width="1432" alt="Screenshot 2024-07-23 at 10 15 49 PM" src="https://github.com/user-attachments/assets/13910181-609c-458e-b8b5-636ade8e78c7">



